### PR TITLE
ACat wrap

### DIFF
--- a/Algebraic/AbstractCategory.agda
+++ b/Algebraic/AbstractCategory.agda
@@ -141,4 +141,8 @@ module Algebraic.AbstractCategory where
         helper : Fin 11 → String × Equation {AbsCatSig} X
         helper i = lookup lawsVector i
 
-  
+    ACatStruct : Set₁
+    ACatStruct = Structure₁ {AbsCatSig}
+
+    ACat : Set₁ 
+    ACat = Σ[ A ∈ ACatStruct ] inVariety₁ {car₁ {AbsCatSig} A} {AbsCatSig} AbsCatLaws A

--- a/Algebraic/Capsules.agda
+++ b/Algebraic/Capsules.agda
@@ -1,0 +1,19 @@
+
+open import Data.Empty using (⊥-elim)
+
+open import Data.Nat using (ℕ)
+open import Data.Fin using (Fin)
+open import Data.Product using (Σ; Σ-syntax; _,_; _×_; proj₁; proj₂)
+open import Data.String using (String)
+open import Data.Vec using (Vec; map)
+
+
+open import Relation.Binary.PropositionalEquality using ( _≡_ )
+
+open import Algebraic.Signatures
+open import Countable.Sets
+
+{-- A minimal countable constructive set theory. --}
+module Algebraic.Capsules where
+
+    

--- a/Algebraic/HomCategories.agda
+++ b/Algebraic/HomCategories.agda
@@ -36,8 +36,8 @@ open import Algebraic.Homomorphism
 module Algebraic.HomCategories where
 
 
-    HomCat : (sig : Signature ) → Structure₁ {AbsCatSig}
-    HomCat sig = (Hom {sig} , ops )
+    HomCatStruct : (sig : Signature ) → ACatStruct
+    HomCatStruct sig = (Hom {sig} , ops )
         where
         ops : (i : Fin 4) → (Operator₁ (Hom {sig}) (proj₂ (proj₂ AbsCatSig i)))
         ops Fin.zero = λ _ → null ▦ refl        -- identity element (valence 0)
@@ -55,7 +55,7 @@ module Algebraic.HomCategories where
             tgtConFun (f ∷ []) = ◄◄ f
 
     -- HomCat satisfies all the abstract category laws
-    certifyHomCat : (sig : Signature) → inVariety₁ {Hom {sig}} {AbsCatSig} AbsCatLaws (HomCat sig)
+    certifyHomCat : (sig : Signature) → inVariety₁ {Hom {sig}} {AbsCatSig} AbsCatLaws (HomCatStruct sig)
     certifyHomCat sig const i = helper i const
       where
         -- THIS IS A HACK TO GET AROUND THE LACK OF DEPENDENT PATTERN MATCHING
@@ -72,7 +72,7 @@ module Algebraic.HomCategories where
         pattern i9 = Fin.suc i8
         pattern i10 = Fin.suc i9
 
-        helper : (i : Fin 11) → (const : Fin 3 → Hom {sig}) → SatEqProp₁ {Fin 3} {AbsCatSig} (HomCat sig) (proj₂ (proj₂ (proj₂ AbsCatLaws) i))
+        helper : (i : Fin 11) → (const : Fin 3 → Hom {sig}) → SatEqProp₁ {Fin 3} {AbsCatSig} (HomCatStruct sig) (proj₂ (proj₂ (proj₂ AbsCatLaws) i))
         helper i0  const₁ = λ const₂ → {!!}     -- 0: leftSinkCompLaw: □ · g = □
         helper i1  const₁ = λ const₂ → {!!}     -- 1: rightSinkCompLaw: f · □ = □
         helper i2  const₁ = λ const₂ → {!!}     -- 2: sinkSrcLaw: □ ◁ = □
@@ -86,5 +86,6 @@ module Algebraic.HomCategories where
         helper i10 const₁ = λ const₂ → {!!}     -- 10: assocLaw: f · (g · h) = (f · g) · h
 
 
-
+    HomCat : (sig : Signature) → ACat
+    HomCat sig = (HomCatStruct sig , certifyHomCat sig )
     

--- a/Algebraic/Structures.agda
+++ b/Algebraic/Structures.agda
@@ -51,19 +51,19 @@ module Algebraic.Structures where
 
 
 
-    Homomorphism : ∀ {sig : Signature} → Structure {sig} → Structure {sig} → Set
-    Homomorphism {sig} (A , opsA) (B , opsB) = 
-        Σ[ f ∈ (asSet A → asSet B) ]
-        ((i : Fin (nOps sig)) →
-            (x : Vec (asSet A) (proj₂ (proj₂ sig i))) →
-                f (opsA i x) ≡ opsB i (map f x)
-        )
+    -- Homomorphism : ∀ {sig : Signature} → Structure {sig} → Structure {sig} → Set
+    -- Homomorphism {sig} (A , opsA) (B , opsB) = 
+    --     Σ[ f ∈ (asSet A → asSet B) ]
+    --     ((i : Fin (nOps sig)) →
+    --         (x : Vec (asSet A) (proj₂ (proj₂ sig i))) →
+    --             f (opsA i x) ≡ opsB i (map f x)
+    --     )
 
-    {-- This is Definition 3.?? : Homomorphism --}
-    Homomorphism₁ : ∀ {sig : Signature} → Structure₁ {sig} → Structure₁ {sig} → Set
-    Homomorphism₁ {sig} (A , opsA) (B , opsB) = 
-        Σ[ f ∈ (A → B) ]
-        ((i : Fin (nOps sig)) →
-            (x : Vec A (proj₂ (proj₂ sig i))) →
-                f (opsA i x) ≡ opsB i (map f x)
-        )        
+    -- {-- This is Definition 3.?? : Homomorphism --}
+    -- Homomorphism₁ : ∀ {sig : Signature} → Structure₁ {sig} → Structure₁ {sig} → Set
+    -- Homomorphism₁ {sig} (A , opsA) (B , opsB) = 
+    --     Σ[ f ∈ (A → B) ]
+    --     ((i : Fin (nOps sig)) →
+    --         (x : Vec A (proj₂ (proj₂ sig i))) →
+    --             f (opsA i x) ≡ opsB i (map f x)
+    --     )        

--- a/Countable/SetCategory.agda
+++ b/Countable/SetCategory.agda
@@ -34,8 +34,8 @@ module Countable.SetCategory where
 
     -- TBD: should this signature belong in some general category module?
 
-    SetCat : Structure₁ {AbsCatSig}
-    SetCat = (ConFun , ops )
+    SetCatStruct : ACatStruct 
+    SetCatStruct = (ConFun , ops )
         where
         ops : (i : Fin 4) → (Operator₁ ConFun (proj₂ (proj₂ AbsCatSig i)))
         ops Fin.zero = λ _ → ▦        -- identity element (valence 0)
@@ -53,7 +53,7 @@ module Countable.SetCategory where
             tgtConFun (f ∷ []) = ◄ f
 
     -- SetCat satisfies all the abstract category laws
-    certifySetCat :  inVariety₁ {ConFun} {AbsCatSig} AbsCatLaws SetCat
+    certifySetCat : inVariety₁ {ConFun} {AbsCatSig} AbsCatLaws SetCatStruct
     certifySetCat const i = helper i const
       where
         -- THIS IS A HACK TO GET AROUND THE LACK OF DEPENDENT PATTERN MATCHING
@@ -70,7 +70,7 @@ module Countable.SetCategory where
         pattern i9 = Fin.suc i8
         pattern i10 = Fin.suc i9
 
-        helper : (i : Fin 11) → (const : Fin 3 → ConFun) → SatEqProp₁ {Fin 3} {AbsCatSig} SetCat (proj₂ (proj₂ (proj₂ AbsCatLaws) i))
+        helper : (i : Fin 11) → (const : Fin 3 → ConFun) → SatEqProp₁ {Fin 3} {AbsCatSig} SetCatStruct (proj₂ (proj₂ (proj₂ AbsCatLaws) i))
         helper i0  const₁ = λ const₂ → leftSinkCompProof (const₂ (# 1))     -- 0: leftSinkCompLaw: □ · g = □
         helper i1  const₁ = λ const₂ → rightSinkCompProof (const₂ (# 0))    -- 1: rightSinkCompLaw: f · □ = □
         helper i2  const₁ = λ const₂ → sinkSrcProof                         -- 2: sinkSrcLaw: □ ◁ = □
@@ -83,6 +83,7 @@ module Countable.SetCategory where
         helper i9  const₁ = λ const₂ → srcCompProof (const₂ (# 0)) (const₂ (# 1))  -- 9: domainCompLaw: (f · g) ◁ = ((f ◁) · g) ◁
         helper i10 const₁ = λ const₂ → ∘-assoc (const₂ (# 0)) (const₂ (# 1)) (const₂ (# 2))  -- 10: assocLaw: f · (g · h) = (f · g) · h
 
-
+    SetCat : ACat
+    SetCat = (SetCatStruct , certifySetCat )
 
     


### PR DESCRIPTION
Added some short names for creating cateogries.
```agda
ACatStruct = Structure {AbsCatSig}
ACat  =  Σ[ A ∈ ACatStruct ] inVariety₁ {car₁ {AbsCatSig} A} {AbsCatSig} AbsCatLaws A
```
So now 
```agda
SetCat : ACat
``` 
and 
```agda
Hom sig : ACat
```